### PR TITLE
On parent setter override instead of resetting

### DIFF
--- a/Editor/SOVariant.cs
+++ b/Editor/SOVariant.cs
@@ -78,7 +78,7 @@ namespace Giezi.Tools
                 AddToChildrenData(AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(parent)), targetGUID);
 
                 if (setToParentData)
-                    InitialiseNewParent();
+                    SetAllFieldsToParent();
                 else
                     InitialiseNewParentOverrides();
             }
@@ -235,13 +235,23 @@ namespace Giezi.Tools
             return children;
         }
 
-        private void InitialiseNewParent()
+        private void SetAllFieldsToParent()
         {
             foreach (FieldInfo fieldInfo in FieldInfoHelper.GetAllFields(_parent.GetType()))
             {
                 object value = FieldInfoHelper.GetFieldRecursively(_parent.GetType(), fieldInfo.Name).GetValue(_parent);
                 FieldInfoHelper.GetFieldRecursively(_target.GetType(), fieldInfo.Name).SetValue(_target, value);
             }
+        }
+
+        public void ResetAllFieldsToParentValue()
+        {
+            List<string> oldOverrides = new List<string>(_overridden);
+            _overridden.Clear();
+            
+            SetAllFieldsToParent();
+            
+            SaveData(_overridden, oldOverrides);
         }
 
         private void InitialiseNewParentOverrides()

--- a/Editor/SOVariantAttributeProcessor.cs
+++ b/Editor/SOVariantAttributeProcessor.cs
@@ -69,6 +69,7 @@ namespace Giezi.Tools
 
                 if (_soVariant._parent != null)
                 {
+                    
                     _soVariant._otherSerializationBackend = new List<string>();
                     foreach (InspectorPropertyInfo propertyInfo in new List<InspectorPropertyInfo>(propertyInfos))
                     {
@@ -88,13 +89,23 @@ namespace Giezi.Tools
                         // ! enable to debug
                         // propertyInfo.GetEditableAttributesList().Add(new ShowDrawerChainAttribute());
                     }
+                
+                    propertyInfos.AddDelegate("Reset all values to Original", () =>
+                    {
+                        _soVariant.ResetAllFieldsToParentValue();
+                        _soVariant._overridden = null;
+                        Property.RefreshSetup();
+                    });
+
+                    var propertyButton = propertyInfos.Last();
+                    propertyInfos.Insert(0, propertyButton);
+                    propertyInfos.RemoveAt(propertyInfos.Count - 1);
+                    propertyButton.GetEditableAttributesList().Add(bxa);
                 }
                 
                 propertyInfos.AddValue("Original", () => _soVariant._parent, ParentSetter);
 
                 InspectorPropertyInfo parentPropertyInfo = propertyInfos.Last();
-
-
                 propertyInfos.Insert(0, parentPropertyInfo);
                 propertyInfos.RemoveAt(propertyInfos.Count - 1);
 

--- a/Editor/SOVariantAttributeProcessor.cs
+++ b/Editor/SOVariantAttributeProcessor.cs
@@ -31,7 +31,7 @@ namespace Giezi.Tools
 
         void ParentSetter(T parent)
         {
-            if(!_soVariant.SetParent(parent))
+            if(!_soVariant.SetParent(parent, false))
                 return;
             
             _soVariant._overridden = null;

--- a/Editor/SOVariantHelper.cs
+++ b/Editor/SOVariantHelper.cs
@@ -17,13 +17,13 @@ namespace Giezi.Tools
 {
     public static class SOVariantHelper<T> where T : ScriptableObject
     {
-        public static bool SetParent(T child, T parent)
+        public static bool SetParent(T child, T parent, bool setToParentValue=true)
         {
             AssertIsSOVariant(parent);
             AssertIsSOVariant(child);
             
             SOVariant<T> soVariant = new SOVariant<T>(child);
-            return soVariant.SetParent(parent);
+            return soVariant.SetParent(parent, setToParentValue);
         }
 
         public static void ChangeFieldOverrideState(T target, string name, bool isOverridden)
@@ -51,25 +51,25 @@ namespace Giezi.Tools
             soVariant.ChangeValue(name, value);   
         }
 
-        public static void SetParentOverrideValue(T child, T parent, string name, object value)
+        public static void SetParentOverrideValue(T child, T parent, string name, object value, bool setToParentValue=true)
         {
             AssertIsSOVariant(parent);
             AssertIsSOVariant(child);
             
             SOVariant<T> soVariant = new SOVariant<T>(child);
-            soVariant.SetParent(parent);
+            soVariant.SetParent(parent, setToParentValue);
             
             soVariant.NotifyOverrideChangeInState(name, true);
             soVariant.ChangeValue(name, value);
         }
 
-        public static void SetParentOverrideValues(T child, T parent, Dictionary<string, object> values)
+        public static void SetParentOverrideValues(T child, T parent, Dictionary<string, object> values, bool setToParentValue=true)
         {
             AssertIsSOVariant(parent);
             AssertIsSOVariant(child);
             
             SOVariant<T> soVariant = new SOVariant<T>(child);
-            soVariant.SetParent(parent);
+            soVariant.SetParent(parent, setToParentValue);
 
             foreach (KeyValuePair<string, object> value in values)
             {


### PR DESCRIPTION
Solves #9, checks which fields are different from the parent and adds them to the override fields.
This is now the default behavior in the GUI, but is added as an optional argument for the helper functions.

Additionally a button to reset all values to the parent values has been added.